### PR TITLE
Test rootfs_write

### DIFF
--- a/flash_utils/flash.py
+++ b/flash_utils/flash.py
@@ -135,8 +135,8 @@ class FlashUtil:
             dest="image_path",
             action="store",
             type=str,
-            help="Absolute path to images dir" \
-                 "(used only with --bootloader, --rootfs, or --full to overwrite <SCRIPT_DIR>).",
+            help="Absolute path to images dir"
+            "(used only with --bootloader, --rootfs, or --full to overwrite <SCRIPT_DIR>).",
         )
 
         # Networking


### PR DESCRIPTION
New test that validates flash_rzboard.py --rootfs usage. Had to mock Popen, serial port write, and tmp filesystem.

Found a bug with the --image_writer, --image_bl2, --image_fip, --image_rootfs commands... Those need patched.