### PR TITLE
Feature/no sleep emmc flashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2024-01-24
+
+### Added
+
+- Initial release 🌱 of the rzboard_flash_util  for [RZBoard](https://github.com/Avnet/RZ-V2L-HUB)
+- Features include:
+  - eMMC flashing
+    - Bootloaders
+    - Linux image
+  - QSPI flashing
+    - Bootloaders
+  - Serial port configuration
+  - RZBoard IP configuration for linux image flashing
+  - Progress bars
+  - Automated [testing / CI](https://github.com/Avnet/rzboard_flash_util/actions)
+- Support for...
+  - Windows, Mac, Linux (Assume Ubuntu)
+
+### Changed
+
+- Latest commits updated EMMC flashing to use serial handshaking and not sleeps. This means the flash utility waits for the RZBoard to send data before continuing the flash process.

--- a/flash_utils/tests/test_flash_util.py
+++ b/flash_utils/tests/test_flash_util.py
@@ -228,9 +228,10 @@ def test_flashing_emmc_bootloader(
     assert "100%" in output.err
 
     mock_serial_port.assert_called_once_with(port=DEFAULT_SERIAL_PORT, baudrate=DEFAULT_BAUD_RATE)
-    mock_serial_port.return_value.write.assert_any_call("\rEM_E\r".encode())
-    mock_serial_port.return_value.write.assert_any_call("\rEM_W\r".encode())
-    mock_serial_port.return_value.write.assert_any_call("\rEM_SECSD\r".encode())
+    mock_serial_port.return_value.write.assert_any_call("EM_E\r".encode())
+    mock_serial_port.return_value.write.assert_any_call("EM_SECSD\r".encode())
+    mock_serial_port.return_value.write.assert_any_call("EM_W\r".encode())
+    mock_serial_port.return_value.read_until.assert_any_call(">".encode())
 
     mock_file_write.assert_has_calls(
         [call(str(flash_writer_image)), call(str(bl2_image)), call(str(fip_image))]
@@ -270,6 +271,7 @@ def test_flashing_qspi_bootloader(
 
     # assert QSPI Being written to
     mock_serial_port.return_value.write.assert_any_call("XLS2\r".encode())
+    mock_serial_port.return_value.read_until.assert_any_call(">".encode())
 
     mock_file_write.assert_has_calls(
         [call(str(flash_writer_image)), call(str(bl2_image)), call(str(fip_image))]


### PR DESCRIPTION
# EMMC serial handshaking, Release 1.0.0

This PR encapsulates the last feature before 1.0.0 release of the flash util: EMMC serial handshaking. Now, EMMC bootloader flashing has `wait_for` logic at the serial read level. This ensures the flash utility doesn't progress state unless the RZBoard is sending certain signals back to us.

QSPI already has handshaking logic.

This marks 1.0.0 release of rzboard_flash_util.
